### PR TITLE
Added branch selection when deploying, closes #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ If you are new to Hubot visit the [getting started](https://hubot.github.com/doc
         HUBOT_BLUEMIX_USER=<Bluemix User ID>
         HUBOT_BLUEMIX_PASSWORD=<Password for the Bluemix use>
         HUBOT_GITHUB_TOKEN=<GitHub personal access token> (optional)
-		HUBOT_GITHUB_DOMAIN=<GitHub domain, omit for public GitHub> (optional)
+	HUBOT_GITHUB_DOMAIN=<GitHub domain, omit for public GitHub> (optional)
 
 5. Start up your bot & off to the races!
 
@@ -72,7 +72,7 @@ Please refer to the [CONTRIBUTING.md](https://github.com/ibm-cloud-solutions/hub
         export HUBOT_BLUEMIX_USER=<Bluemix User ID>
         export HUBOT_BLUEMIX_PASSWORD=<Password for the Bluemix use>
         export HUBOT_GITHUB_TOKEN=<GitHub personal access token> (optional)
-		export HUBOT_GITHUB_DOMAIN=<GitHub domain, omit for public GitHub> (optional)
+	export HUBOT_GITHUB_DOMAIN=<GitHub domain, omit for public GitHub> (optional)
 
 3. In order to view content in chat clients you will need to add `hubot-ibmcloud-formatter` to your `external-scripts.json` file. Additionally, if you want to use `hubot-help` to make sure your command documentation is correct. Create `external-scripts.json` in the root of this project, with the following contents:
 

--- a/README.md
+++ b/README.md
@@ -30,16 +30,19 @@ If you are new to Hubot visit the [getting started](https://hubot.github.com/doc
         HUBOT_BLUEMIX_SPACE=<Bluemix space>
         HUBOT_BLUEMIX_USER=<Bluemix User ID>
         HUBOT_BLUEMIX_PASSWORD=<Password for the Bluemix use>
+        HUBOT_GITHUB_TOKEN=<GitHub personal access token> (optional)
+		HUBOT_GITHUB_DOMAIN=<GitHub domain, omit for public GitHub> (optional)
 
 5. Start up your bot & off to the races!
 
 ## Commands
 
-- `hubot deploy` - Deployment setup with prompts for application and GitHub URL.
-- `hubot deploy <app>` - Deployment setup for , or prompt you to provide a GitHub URL to deploy to .
-- `hubot deploy <url>` - Deployment setup for and prompt you for the Bluemix application name.
-- `hubot deploy <app> <url>` - Deployment of as on Bluemix.
-- `hubot deploy help`- Show available deploy commands.
+- `hubot deploy` - Deployment setup with prompts for application, GitHub URL and branch.
+- `hubot deploy <app>` - Deployment setup for app, or prompt you to provide a GitHub URL and branch to depoy to.
+- `hubot deploy <url>` - Deployment setup for url and prompt you for the Bluemix application name and branch.
+- `hubot deploy <app> <url>` - Deployment of app with url, prompt for branch if not provided.
+- `hubot deploy help` - Show available commands in the deploy category.
+
 
 Your github repository should contain a `manifest.yml` that describes the deployment of the application.
 More information about application deployment and manifest files can be read here: https://console.ng.bluemix.net/docs/manageapps/depapps.html#deployingapps
@@ -68,6 +71,8 @@ Please refer to the [CONTRIBUTING.md](https://github.com/ibm-cloud-solutions/hub
         export HUBOT_BLUEMIX_SPACE=<Bluemix space>
         export HUBOT_BLUEMIX_USER=<Bluemix User ID>
         export HUBOT_BLUEMIX_PASSWORD=<Password for the Bluemix use>
+        export HUBOT_GITHUB_TOKEN=<GitHub personal access token> (optional)
+		export HUBOT_GITHUB_DOMAIN=<GitHub domain, omit for public GitHub> (optional)
 
 3. In order to view content in chat clients you will need to add `hubot-ibmcloud-formatter` to your `external-scripts.json` file. Additionally, if you want to use `hubot-help` to make sure your command documentation is correct. Create `external-scripts.json` in the root of this project, with the following contents:
 

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
   ],
   "dependencies": {
     "adm-zip": "^0.4.7",
-    "yamljs": "^0.2.8"
+    "yamljs": "^0.2.8",
+		"github": "^3.0.0"
   },
   "config": {
     "commitizen": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
   "dependencies": {
     "adm-zip": "^0.4.7",
     "yamljs": "^0.2.8",
-		"github": "^3.0.0"
+    "github": "^3.0.0"
   },
   "config": {
     "commitizen": {

--- a/src/lib/github.js
+++ b/src/lib/github.js
@@ -1,0 +1,24 @@
+
+/*
+  * Licensed Materials - Property of IBM
+  * (C) Copyright IBM Corp. 2016. All Rights Reserved.
+  * US Government Users Restricted Rights - Use, duplication or
+  * disclosure restricted by GSA ADP Schedule Contract with IBM Corp.
+  */
+'use strict';
+
+const Github = require('github');
+
+const gh = new Github({
+	version: '3.0.0',
+	host: process.env.HUBOT_GITHUB_DOMAIN || 'api.github.com'
+});
+
+if (process.env.HUBOT_GITHUB_TOKEN) {
+	gh.authenticate({
+		type: 'token',
+		token: process.env.HUBOT_GITHUB_TOKEN
+	});
+}
+
+module.exports = gh;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -9,7 +9,7 @@
 
    "github.deploy.app.select": "Which app would you like to deploy?  Here are the ones I know about:",
    "github.deploy.failure": "Sorry, I tried my best.",
-   "github.deploy.in.progress": "Deploying *%s* from master branch of %s.",
+   "github.deploy.in.progress": "Deploying *%s* from *%s* branch of %s.",
    "github.deploy.in.progress.matching": "Deploying matching apps.",
    "github.deploy.started": "Deployment *%s* has been started.",
    "github.deploy.name.invalid": "You didn't give me a valid app name.  I would love to do something with this, but I cannot.",
@@ -38,6 +38,7 @@
    "github.deploy.error": "A deployment error occurred for app *%s*: %s.",
    "github.deploy.manifest.error": "Invalid manifest.yml file for app *%s*.",
    "github.deploy.route.error": "Error adding route to the application: *%s*.",
+	 "github.deploy.branch.prompt": "Which *branch* would you like to deploy?",
 
    "help.github.deploy": "Deployment setup with prompts for application and GitHub URL.",
    "help.github.deploy.app": "Deployment setup for <app>, or prompt you to provide a GitHub URL to deploy to <app>.",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -38,7 +38,7 @@
    "github.deploy.error": "A deployment error occurred for app *%s*: %s.",
    "github.deploy.manifest.error": "Invalid manifest.yml file for app *%s*.",
    "github.deploy.route.error": "Error adding route to the application: *%s*.",
-	 "github.deploy.branch.prompt": "Which *branch* would you like to deploy?",
+   "github.deploy.branch.prompt": "Which *branch* would you like to deploy?",
 
    "help.github.deploy": "Deployment setup with prompts for application and GitHub URL.",
    "help.github.deploy.app": "Deployment setup for <app>, or prompt you to provide a GitHub URL to deploy to <app>.",

--- a/src/scripts/deploy.js
+++ b/src/scripts/deploy.js
@@ -7,10 +7,10 @@
 //	 HUBOT_BLUEMIX_SPACE Bluemix space
 //	 HUBOT_BLUEMIX_USER Bluemix User ID
 //	 HUBOT_BLUEMIX_PASSWORD Password for the Bluemix User
-//   HUBOT_GITHUB_TOKEN <optional> Github API Auth token
+//   	 HUBOT_GITHUB_TOKEN <optional> Github API Auth token
 //
 // Commands:
-//  hubot deploy help - Show available commands in the deploy category.
+//  	hubot deploy help - Show available commands in the deploy category.
 //	hubot deploy - Deployment setup with prompts for application, GitHub URL and branch.
 //	hubot deploy <app> - Deployment setup for app, or prompt you to provide a GitHub URL and branch to depoy to.
 //	hubot deploy <url> - Deployment setup for url and prompt you for the Bluemix application name and branch.
@@ -306,17 +306,13 @@ const sortRegisterInput = (input1, input2) => {
 };
 
 const deploy = (app, appGuid, spaceGuid, spaceName, robot, res) => {
-	const branch = app.branch;
-	const reponame = app.repo;
-	const repoowner = app.user;
-
 	let domain = '';
 	let appZip;
 	let applicationGuid;
 	let temp = os.tmpdir();
 	let now = Date.now();
 	let deploymentDir = `${temp}/${now}`;
-	let filename = `${deploymentDir}/${reponame}_${now}.zip`;
+	let filename = `${deploymentDir}/${app.repo}_${now}.zip`;
 	let applicationDomain;
 	let applicationHost;
 	let applicationDomainGuid;
@@ -331,7 +327,7 @@ const deploy = (app, appGuid, spaceGuid, spaceName, robot, res) => {
 	}
 
 	robot.logger.info(`${TAG}: Beginning deployment steps for ${app.app} ...`);
-	getUserRepo(robot, domain, repoowner, reponame, branch)
+	getUserRepo(robot, domain, app.user, app.repo, app.branch)
 	.then((bf) => {
 		let message = i18n.__('github.deploy.obtaining.zip', app.app);
 		robot.emit('ibmcloud.formatter', { response: res, message: message});

--- a/src/scripts/deploy.js
+++ b/src/scripts/deploy.js
@@ -293,9 +293,13 @@ const sortRegisterInput = (input1, input2) => {
 
 const deploy = (app, appGuid, spaceGuid, spaceName, robot, res) => {
 
-	const urlTokens = app.url.split('/');
+	const regex = /(.*)\/tree\/(.*)/;
+	const match = regex.exec(app.url);
+	const urlTokens = match !== null ? match[1] : app.url.split('/');
+	const branch = match !== null ? match[2] : undefined;
 	const reponame = urlTokens.pop();
 	const repoowner = urlTokens.pop();
+
 	let domain = '';
 	let appZip;
 	let applicationGuid;
@@ -317,7 +321,7 @@ const deploy = (app, appGuid, spaceGuid, spaceName, robot, res) => {
 	}
 
 	robot.logger.info(`${TAG}: Beginning deployment steps for ${app.app} ...`);
-	getUserRepo(robot, domain, repoowner, reponame)
+	getUserRepo(robot, domain, repoowner, reponame, branch)
 	.then((bf) => {
 		let message = i18n.__('github.deploy.obtaining.zip', app.app);
 		robot.emit('ibmcloud.formatter', { response: res, message: message});

--- a/src/scripts/deploy.js
+++ b/src/scripts/deploy.js
@@ -282,7 +282,6 @@ module.exports = function(robot) {
 	});
 
 	robot.respond(/deploy\s+(\S+)\s+(\S+)$/i, {id: 'github.deploy'}, (res) => {
-		console.log("YOU ARE HERE LALALLALALALALA");
 		robot.logger.debug(`${TAG}: res.message.text=${res.message.text}.`);
 
 		const entry = sortRegisterInput(res.match[1], res.match[2]);
@@ -305,9 +304,6 @@ const sortRegisterInput = (input1, input2) => {
 };
 
 const deploy = (app, appGuid, spaceGuid, spaceName, robot, res) => {
-
-	console.log(app);
-
 	const urlTokens = app.url.split('/');
 	const branch = app.branch;
 	const reponame = urlTokens.pop();
@@ -598,7 +594,6 @@ function asyncGet(robot, url) {
 };
 
 function processAppDeploy(robot, res, switchBoard, entry){
-	console.log('AN NOW HERE');
 	let apps = robot.brain.get('github-apps') || {};
 
 	if (!entry) {

--- a/test/bluemix.github.deploy.cognitive.test.js
+++ b/test/bluemix.github.deploy.cognitive.test.js
@@ -66,14 +66,20 @@ describe('Interacting with Deploy via NLS', function() {
 	});
 
 	context('user calls `I want to deploy my application`', function() {
+		let replyFn = function(msg) {
+			if (msg.indexOf('Which *branch* would you like to deploy?') >= 0) {
+				return room.user.say('anId', '@hubot master');
+			}
+		};
+
 		it('should respond with the application deploy', function(done) {
 			room.robot.on('ibmcloud.formatter', (event) => {
 				expect(event.message).to.be.a('string');
-				expect(event.message).to.contain(i18n.__('github.deploy.in.progress', 'node-helloworld', 'normanb/node-helloworld'));
+				expect(event.message).to.contain(i18n.__('github.deploy.in.progress', 'node-helloworld', 'master', 'normanb/node-helloworld'));
 				done();
 			});
 
-			const res = { message: {text: 'start application deployment', user: {id: 'anId'}}, response: room };
+			const res = { message: {text: 'start application deployment', user: {id: 'anId'}}, response: room, reply: replyFn };
 			room.robot.emit('github.deploy', res, {appname: 'node-helloworld', url: 'normanb/node-helloworld'});
 		});
 	});

--- a/test/bluemix.github.deploy.test.js
+++ b/test/bluemix.github.deploy.test.js
@@ -195,11 +195,17 @@ describe('Interacting with Bluemix via Slack', function() {
 			return room.user.say('mimiron', 'yes');
 		}).then(() => {
 			expect(room.messages.length).to.eql(10);
+			expect(room.messages[9][1]).to.be.a('String');
+			expect(room.messages[9]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
+			return room.user.say('mimiron', '@hubot master');
+		}).then(() => {
+			expect(room.messages.length).to.eql(12);
+			expect(room.messages[11]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'node-helloworld', 'master', 'normanb/node-helloworld')}`]);
 		});
 	});
 
 	context('user calls `deploy app`', function() {
-		it('should respond with the deploy steps and fail', function() {
+		it('should respond with the deploy steps', function() {
 			return room.user.say('mimiron', '@hubot deploy app1').then(() => {
 				expect(room.messages.length).to.eql(3);
 				expect(room.messages[1][1]).to.be.a('String');
@@ -209,6 +215,14 @@ describe('Interacting with Bluemix via Slack', function() {
 				expect(room.messages[4]).to.eql(['hubot', '@mimiron ' + i18n.__('general.awesome')]);
 				expect(room.messages[5]).to.eql(['hubot', '@mimiron ' + i18n.__('github.deploy.repo.name.prompt')]);
 				return room.user.say('mimiron', 'user/helloworld');
+			}).then(() => {
+				expect(room.messages.length).to.eql(8);
+				expect(room.messages[7][1]).to.be.a('String');
+				expect(room.messages[7]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
+				return room.user.say('mimiron', '@hubot master');
+			}).then(() => {
+				expect(room.messages.length).to.eql(10);
+				expect(room.messages[9]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'app1', 'master', 'user/helloworld')}`]);
 			});
 		});
 
@@ -277,6 +291,15 @@ describe('Interacting with Bluemix via Slack', function() {
 		});
 	});
 
+	context('user calls `deploy url` with branch', function() {
+		it('should respond with the deploy steps', function() {
+			return room.user.say('mimiron', '@hubot deploy app user/helloworld/tree/master').then(() => {
+				expect(room.messages.length).to.eql(2);
+				expect(room.messages[1]).to.eql(['hubot', '@mimiron ' + i18n.__('github.deploy.in.progress', 'app', 'master', 'user/helloworld')]);
+			});
+		});
+	});
+
 	context('user calls `deploy app` with a zip and it exists', function() {
 		beforeEach(function() {
 			room.robot.brain.set('github-apps', {
@@ -293,12 +316,32 @@ describe('Interacting with Bluemix via Slack', function() {
 				expect(room.messages[1][1]).to.be.a('String');
 				expect(room.messages[1]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress.matching')}`]);
 				expect(room.messages[2][1]).to.be.a('String');
-				expect(room.messages[2]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
-				return room.user.say('mimiron', '@hubot master');
-			}).then(() => {
-				expect(room.messages.length).to.eql(5);
-				expect(room.messages[4][1]).to.be.a('String');
-				expect(room.messages[4]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'manifestTest', 'master', 'user/manifestTest')}`]);
+				expect(room.messages[2]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'manifestTest', 'master', 'user/manifestTest')}`]);
+			});
+		});
+	});
+
+	context('user calls `deploy app` with a zip and it exists with multiple Branches', function() {
+		beforeEach(function() {
+			room.robot.brain.set('github-apps', {
+				manifestTest: 'user/manifestTestMultipleBranches'
+			});
+		});
+		afterEach(function() {
+			room.robot.brain.remove('github-apps');
+		});
+
+		it('should respond with list of branches to select from', function() {
+			return room.user.say('mimiron', '@hubot deploy manifestTest').then(() => {
+				expect(room.messages.length).to.eql(3);
+				expect(room.messages[1][1]).to.be.a('String');
+				expect(room.messages[1]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress.matching')}`]);
+				expect(room.messages[2][1]).to.be.a('String');
+				expect(room.messages[2][1]).to.contain(i18n.__('github.deploy.branch.prompt'));
+				return room.user.say('mimiron', '@hubot 2').then(() => {
+					expect(room.messages.length).to.eql(5);
+					expect(room.messages[4]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'manifestTest', 'test-branch', 'user/manifestTestMultipleBranches')}`]);
+				});
 			});
 		});
 	});
@@ -329,4 +372,17 @@ describe('Interacting with Bluemix via Slack', function() {
 		});
 	});
 
+	// context('user calls `deploy app` with a zip for new app', function() {
+	//
+	// 	it.only('should respond with the apps that it will deploy with zip', function() {
+	// 		return room.user.say('mimiron', '@hubot deploy manifestTest user/manifestTest').then(() => {
+	// 			expect(room.messages.length).to.eql(2);
+	// 			expect(room.messages[1][1]).to.be.a('String');
+	// 			expect(room.messages[1]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress.matching')}`]);
+	// 			expect(room.messages[0][1]).to.be.a('String');
+	// 			expect(room.messages[0]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
+	//
+	// 		});
+	// 	});
+	// });
 });

--- a/test/bluemix.github.deploy.test.js
+++ b/test/bluemix.github.deploy.test.js
@@ -371,18 +371,4 @@ describe('Interacting with Bluemix via Slack', function() {
 			});
 		});
 	});
-
-	// context('user calls `deploy app` with a zip for new app', function() {
-	//
-	// 	it.only('should respond with the apps that it will deploy with zip', function() {
-	// 		return room.user.say('mimiron', '@hubot deploy manifestTest user/manifestTest').then(() => {
-	// 			expect(room.messages.length).to.eql(2);
-	// 			expect(room.messages[1][1]).to.be.a('String');
-	// 			expect(room.messages[1]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress.matching')}`]);
-	// 			expect(room.messages[0][1]).to.be.a('String');
-	// 			expect(room.messages[0]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
-	//
-	// 		});
-	// 	});
-	// });
 });

--- a/test/bluemix.github.deploy.test.js
+++ b/test/bluemix.github.deploy.test.js
@@ -114,7 +114,12 @@ describe('Interacting with Bluemix via Slack', function() {
 				return room.user.say('mimiron', '@hubot node-helloworld');
 			}).then(() => {
 				expect(room.messages.length).to.eql(5);
-				expect(room.messages[4]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'node-helloworld', 'normanb/node-helloworld')}`]);
+				expect(room.messages[4][1]).to.be.a('String');
+				expect(room.messages[4]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
+				return room.user.say('mimiron', '@hubot master');
+			}).then(() => {
+				expect(room.messages.length).to.eql(7);
+				expect(room.messages[6]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'node-helloworld', 'master', 'normanb/node-helloworld')}`]);
 			});
 		});
 	});
@@ -154,12 +159,22 @@ describe('Interacting with Bluemix via Slack', function() {
 			return room.user.say('mimiron', '@hubot deploy normanb/node-helloworld node-helloworld').then(() => {
 				expect(room.messages.length).to.eql(2);
 				expect(room.messages[1][1]).to.be.a('String');
-				expect(room.messages[1]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'node-helloworld', 'normanb/node-helloworld')}`]);
-				return room.user.say('mimiron', '@hubot deploy node-helloworld normanb/node-helloworld');
+				expect(room.messages[1]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
+				return room.user.say('mimiron', '@hubot master');
 			}).then(() => {
 				expect(room.messages.length).to.eql(4);
 				expect(room.messages[3][1]).to.be.a('String');
-				expect(room.messages[3]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'node-helloworld', 'normanb/node-helloworld')}`]);
+				expect(room.messages[3]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'node-helloworld', 'master', 'normanb/node-helloworld')}`]);
+				return room.user.say('mimiron', '@hubot deploy node-helloworld normanb/node-helloworld');
+			}).then(() => {
+				expect(room.messages.length).to.eql(8);
+				expect(room.messages[7][1]).to.be.a('String');
+				expect(room.messages[7]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
+				return room.user.say('mimiron', '@hubot master');
+			}).then(() => {
+				expect(room.messages.length).to.eql(10);
+				expect(room.messages[9][1]).to.be.a('String');
+				expect(room.messages[9]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'node-helloworld', 'master', 'normanb/node-helloworld')}`]);
 			});
 		});
 	});
@@ -230,7 +245,12 @@ describe('Interacting with Bluemix via Slack', function() {
 				expect(room.messages[1][1]).to.be.a('String');
 				expect(room.messages[1]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress.matching')}`]);
 				expect(room.messages[2][1]).to.be.a('String');
-				expect(room.messages[2]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'node-helloworld', 'normanb/node-helloworld')}`]);
+				expect(room.messages[2]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
+				return room.user.say('mimiron', '@hubot master');
+			}).then(() => {
+				expect(room.messages.length).to.eql(5);
+				expect(room.messages[4][1]).to.be.a('String');
+				expect(room.messages[4]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'node-helloworld', 'master', 'normanb/node-helloworld')}`]);
 			});
 		});
 	});
@@ -247,7 +267,12 @@ describe('Interacting with Bluemix via Slack', function() {
 				return room.user.say('mimiron', 'helloworld');
 			}).then(() => {
 				expect(room.messages.length).to.eql(7);
-				expect(room.messages[6]).to.eql(['hubot', '@mimiron ' + i18n.__('github.deploy.in.progress', 'helloworld', 'user/helloworld')]);
+				expect(room.messages[6][1]).to.be.a('String');
+				expect(room.messages[6]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
+				return room.user.say('mimiron', '@hubot master');
+			}).then(() => {
+				expect(room.messages.length).to.eql(9);
+				expect(room.messages[8]).to.eql(['hubot', '@mimiron ' + i18n.__('github.deploy.in.progress', 'helloworld', 'master', 'user/helloworld')]);
 			});
 		});
 	});
@@ -268,7 +293,12 @@ describe('Interacting with Bluemix via Slack', function() {
 				expect(room.messages[1][1]).to.be.a('String');
 				expect(room.messages[1]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress.matching')}`]);
 				expect(room.messages[2][1]).to.be.a('String');
-				expect(room.messages[2]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'manifestTest', 'user/manifestTest')}`]);
+				expect(room.messages[2]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
+				return room.user.say('mimiron', '@hubot master');
+			}).then(() => {
+				expect(room.messages.length).to.eql(5);
+				expect(room.messages[4][1]).to.be.a('String');
+				expect(room.messages[4]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'manifestTest', 'master', 'user/manifestTest')}`]);
 			});
 		});
 	});
@@ -289,7 +319,12 @@ describe('Interacting with Bluemix via Slack', function() {
 				expect(room.messages[1][1]).to.be.a('String');
 				expect(room.messages[1]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress.matching')}`]);
 				expect(room.messages[2][1]).to.be.a('String');
-				expect(room.messages[2]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'manifestTestNoApp', 'user/manifestTestNoApp')}`]);
+				expect(room.messages[2]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.branch.prompt')}`]);
+				return room.user.say('mimiron', '@hubot master');
+			}).then(() => {
+				expect(room.messages.length).to.eql(5);
+				expect(room.messages[4][1]).to.be.a('String');
+				expect(room.messages[4]).to.eql(['hubot', `@mimiron ${i18n.__('github.deploy.in.progress', 'manifestTestNoApp', 'master', 'user/manifestTestNoApp')}`]);
 			});
 		});
 	});

--- a/test/mock.utils.gh.js
+++ b/test/mock.utils.gh.js
@@ -7,15 +7,22 @@
 'use strict';
 
 const nock = require('nock');
+const path = require('path');
 nock.disableNetConnect();
 nock.enableNetConnect('localhost');
 
-const endpoint = 'https://github.com:443';
+const ghApiEndpoint = 'https://api.github.com';
+const ghEndpoint = 'https://github.com';
+
+const mockBranches = require(path.resolve(__dirname, 'resources', 'mock.branches.json'));
 
 module.exports = {
 
 	setupMockery: function() {
-		let ghScope = nock(endpoint)
+		let ghScope = nock(ghEndpoint)
+			.persist();
+
+		let ghApiScope = nock(ghApiEndpoint)
 			.persist();
 
 		ghScope.get('/user/helloworld/archive/master.zip')
@@ -27,7 +34,19 @@ module.exports = {
 		ghScope.get('/user/manifestTest/archive/master.zip')
 			.replyWithFile(200, __dirname + '/resources/manifestTest/master.zip');
 
+		ghScope.get('/user/manifestTest/archive/master.zip')
+			.replyWithFile(200, __dirname + '/resources/manifestTest/master.zip');
+
 		ghScope.get('/user/manifestTestNoApp/archive/master.zip')
-				.replyWithFile(200, __dirname + '/resources/manifestTestNoApp/master.zip');
+			.replyWithFile(200, __dirname + '/resources/manifestTestNoApp/master.zip');
+
+		ghScope.get('/user/manifestTestMultipleBranches/archive/test-branch.zip')
+			.replyWithFile(200, __dirname + '/resources/manifestTest/master.zip');
+
+		ghApiScope.get('/repos/user/manifestTest/branches')
+			.reply(200, mockBranches.oneBranch);
+
+		ghApiScope.get('/repos/user/manifestTestMultipleBranches/branches')
+			.reply(200, mockBranches.multipleBranches);
 	}
 };

--- a/test/resources/mock.branches.json
+++ b/test/resources/mock.branches.json
@@ -1,29 +1,27 @@
 {
-	"multipleBranches":
- 		[
-			{
-				"name": "master",
-		    "commit": {
-		      "sha": "mockCommit",
-		      "url": "mockURL"
-		    }
-			},
-			{
-				"name": "test-branch",
-				"commit": {
-					"sha": "mockCommit",
-					"url": "mockURL"
-				}
+	"multipleBranches": [
+		{
+			"name": "master",
+			"commit": {
+				"sha": "mockCommit",
+		      		"url": "mockURL"
 			}
-		],
-	"oneBranch":
-		[
-			{
-				"name": "master",
-				"commit": {
-					"sha": "mockCommit",
-					"url": "mockURL"
-				}
+		},
+		{
+			"name": "test-branch",
+			"commit": {
+				"sha": "mockCommit",
+				"url": "mockURL"
 			}
-		]
+		}
+	],
+	"oneBranch": [
+		{
+			"name": "master",
+			"commit": {
+				"sha": "mockCommit",
+				"url": "mockURL"
+			}
+		}
+	]
 }

--- a/test/resources/mock.branches.json
+++ b/test/resources/mock.branches.json
@@ -1,0 +1,29 @@
+{
+	"multipleBranches":
+ 		[
+			{
+				"name": "master",
+		    "commit": {
+		      "sha": "mockCommit",
+		      "url": "mockURL"
+		    }
+			},
+			{
+				"name": "test-branch",
+				"commit": {
+					"sha": "mockCommit",
+					"url": "mockURL"
+				}
+			}
+		],
+	"oneBranch":
+		[
+			{
+				"name": "master",
+				"commit": {
+					"sha": "mockCommit",
+					"url": "mockURL"
+				}
+			}
+		]
+}


### PR DESCRIPTION
You can now specify a branch when deploying a project:
- Requests branches from repo and lists them for the user to pick
- If only one branch exists, automatically deploy it
- If error with request (rate limit reached) check for user provided `HUBOT_GITHUB_TOKEN`
- If token not provided or another error with the request, user is prompted to manually enter `branch`

**Note:** Tests are updated to cover the changes but not using the new testing guidelines established in [CONTRIBUTING.md](https://github.com/ibm-cloud-solutions/hubot-ibmcloud-deploy/blob/master/CONTRIBUTING.md). Currently working on a different PR for updating the tests to use `portend`. #24 

@aeweidne assigned to you since you initially worked on this module.
