### PR TITLE
Fix multiple prompts when listing known apps, closes #27

### DIFF
--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -7,7 +7,7 @@
    "general.ok.another.time": "Ok.  Maybe another time.",
    "general.safe.this.time": "Ok, '%s' is safe this time around.",
 
-   "github.deploy.app.select": "Which app would you like to deploy?  Here are the ones I know about:",
+   "github.deploy.app.select": "Which app would you like to deploy?",
    "github.deploy.failure": "Sorry, I tried my best.",
    "github.deploy.in.progress": "Deploying *%s* from *%s* branch of %s.",
    "github.deploy.in.progress.matching": "Deploying matching apps.",

--- a/src/scripts/deploy.js
+++ b/src/scripts/deploy.js
@@ -659,7 +659,7 @@ function getEntry(robot, res, switchBoard, entry) {
 				}
 				else {
 					let prompt = i18n.__('github.deploy.branch.prompt');
-					utils.getExpectedResponse(res, robot, switchBoard, prompt, /(?:\S+\s+){1}(\S+)/i).then((branchRes) => {
+					utils.getExpectedResponse(res, robot, switchBoard, prompt, /(.*)/i).then((branchRes) => {
 						entry.branch = branchRes.match[1];
 						resolve(entry);
 					}).catch((err) => {


### PR DESCRIPTION
In the previous implementation, hubot would prompt the user multiple times (once for each attachment) to select an app from a list of attachments like so:

<img width="459" alt="screen shot 2016-09-16 at 1 42 37 pm" src="https://cloud.githubusercontent.com/assets/4438261/18595604/77e0b016-7c13-11e6-9ebf-e1786cdfc4ad.png">

This fix lists the list once at the beginning and, if a selection is invalid, prompts the user again until a valid (or exit) selection is made.
